### PR TITLE
fix: correct sitemap, feed protocol

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -80,10 +80,10 @@ module.exports = {
           },
         ],
         sitemap: {
-          hostname: 'http://nguyenhy.github.io/'
+          hostname: 'https://nguyenhy.github.io/'
         },
         feed: {
-          canonical_base: 'http://nguyenhy.github.io/'
+          canonical_base: 'https://nguyenhy.github.io/'
         }
       },
     ],


### PR DESCRIPTION
Attempt to fix error while check for build
```
Although you have enabled HTTPS on your site, we’ve detected some content that’s still being served over an HTTP connection
```